### PR TITLE
POST request data 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jdk-alpine
 
 #RUN mvn clean compile assembly:single
 
-COPY target/seth-1.3.1-Snapshot-jar-with-dependencies.jar /app/seth.jar
+COPY target/seth-1.3.2-Snapshot-jar-with-dependencies.jar /app/seth.jar
+COPY resources/mutations.txt /app/resources/mutations.txt
 WORKDIR /app
 
 EXPOSE 8080

--- a/src/main/java/edu/uchsc/ccp/nlp/ei/mutation/MutationFinder.java
+++ b/src/main/java/edu/uchsc/ccp/nlp/ei/mutation/MutationFinder.java
@@ -153,7 +153,7 @@ public class MutationFinder extends MutationExtractor {
             br = new BufferedReader(new FileReader(file));
             loadRegularExpressionsFromStream(br);
         } catch (FileNotFoundException fnfe) {
-            error("The file containing regular expressions could not be found: " + file.getAbsolutePath() + File.separator + file.getName());
+            error("The file containing regular expressions could not be found: " + file.getAbsolutePath());
             //fnfe.printStackTrace();
             loadRegularExpressionsFromJar("/resources/mutations.txt");
         }

--- a/src/main/java/seth/seth/webservice/MessageResource.java
+++ b/src/main/java/seth/seth/webservice/MessageResource.java
@@ -33,10 +33,10 @@ public class MessageResource     {
 
     //curl -X POST http://localhost:8080/rest/message/post/p.T123C%20and%20Val158Tyr
     @POST
-    @Path("/post/{param}")
+    @Path("/post/")
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response createTrackInJSON(@PathParam("param") String msg) {
+    public Response createTrackInJSON(String msg) {
 
         List<MutationMention> mentions = seth.findMutations(msg);
 


### PR DESCRIPTION
POST request data should be in the body of the request not in the URL. Since there is a character limit in the URL, big texts can otherwise not be send to the API.

Other fixes:
- mutations.txt missing in Docker container
- Path for missing mutations.txt is incorrect `MutationFinderThe file containing regular expressions could not be found: /app/resources/mutations.txt/mutations.txt`
