### PR TITLE
Update dependencies to support Scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /seth.iml
+.idea/
+.target/
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-See http://rockt.github.com/SETH/
+See http://rockt.github.io/SETH/
 
 ## Contributors
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,12 @@
     </issueManagement>
 
     <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.version>1.19</jersey.version>
     </properties>
+
 
     <developers>
         <developer>
@@ -82,14 +85,14 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.12</version>
+            <version>2.12.15</version>
         </dependency>
 
         <!-- Required for Backus-Naur grammar -->
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_2.11</artifactId>
-            <version>1.0.3</version>
+            <artifactId>scala-parser-combinators_2.12</artifactId>
+            <version>2.1.1</version>
         </dependency>
 
         <!-- A library for converting between Java and Scala collections.-->
@@ -101,8 +104,8 @@
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
-            <version>2.2.6</version>
+            <artifactId>scalatest_2.12</artifactId>
+            <version>3.2.12</version>
             <scope>test</scope>
         </dependency>
 
@@ -203,6 +206,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -239,6 +243,13 @@
             <plugin>
                 <groupId>org.scala-tools</groupId>
                 <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.2</version>
+                <configuration>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                    </args>
+                </configuration>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>
@@ -262,6 +273,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -284,6 +296,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,12 @@
     <developers>
         <developer>
             <name>Philippe Thomas</name>
-            <email></email>
             <organization>Humboldt Universitaet zu Berlin</organization>
             <organizationUrl>https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi</organizationUrl>
         </developer>
 
         <developer>
             <name>Tim Rocktaeschel</name>
-            <email></email>
             <organization>Humboldt Universitaet zu Berlin</organization>
             <organizationUrl>https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi</organizationUrl>
         </developer>
@@ -57,14 +55,12 @@
     <contributors>
         <contributor>
             <name>Yvonne Mayer</name>
-            <email></email>
             <organization>Humboldt Universitaet zu Berlin</organization>
             <organizationUrl>https://www.informatik.hu-berlin.de/de/forschung/gebiete/wbi</organizationUrl>
         </contributor>
 
         <contributor>
             <name>Eugene Brevdo</name>
-            <email></email>
             <url>https://github.com/ebrevdo</url>
             <organization>Department of Electrical Engineering at Princeton University</organization>
             <organizationUrl>http://ee.princeton.edu/</organizationUrl>
@@ -140,16 +136,19 @@
         <!--  log4j as the underlying logging framework -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.22</version>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
         </dependency>
 
-        <!-- log4j -->
+
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
         </dependency>
+
 
         <!-- Libraries for REST Service -->
         <dependency>
@@ -158,9 +157,9 @@
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
-            <version>${jersey.version}</version>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+            <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/src/main/java/seth/SETH.java
+++ b/src/main/java/seth/SETH.java
@@ -9,8 +9,8 @@ import seth.ner.wrapper.Type;
 
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.util.*;
 
@@ -161,7 +161,7 @@ public class SETH {
 
         //Post-processing:
         //Some mentions can be found be different tools. Thus, we remove all duplicates by preserving the longest element
-        //E.g., IVS2 + 1G>A is recognized  Mutationfinder (2+1G>A) and correctly Tool.Regex
+        //E.g., IVS2 + 1G>A is recognized  MutationFinder (2+1G>A) and correctly Tool.Regex
         List<MutationMention> result = new ArrayList<MutationMention>(mutations.size());
         for (MutationMention mm : mutations) {
 
@@ -189,10 +189,10 @@ public class SETH {
 
                     if (mm.getTool() == MutationMention.Tool.SETH && m.getTool() == MutationMention.Tool.DBSNP) {
                         contained = true;
-                        break loop;
+                        break;
                     } else if (m.getTool() == MutationMention.Tool.SETH && mm.getTool() == MutationMention.Tool.DBSNP) {
                         result.remove(m);
-                        break loop;
+                        break;
                     }
                     //else we do return two mutations!!
                 }
@@ -200,7 +200,7 @@ public class SETH {
                 //If the new mention is smaller than the mention contained in the result, ignore the smaller one
                 else if (mm.getStart() >= m.getStart() && mm.getEnd() <= m.getEnd() && equal) {
                     contained = true;
-                    break loop;
+                    break;
                 }
 
                 //If the new mention is longer, remove the old (smaller) mention and add the new one
@@ -222,9 +222,9 @@ public class SETH {
     /**
      * Minimal example to perform named entity recognition and normalization using SETH
      *
-     * @param args
-     * @throws SQLException
-     * @throws IOException
+     * @param args -- args
+     * @throws SQLException -- SQLException
+     * @throws IOException -- IOException
      */
     public static void main(String[] args) throws SQLException, IOException {
         String text = "p.A123T and Val158Met";
@@ -242,11 +242,11 @@ public class SETH {
         }
 
 
-        /** Part 2: Normalization of mutation mentions to dbSNP
-         * This part communicates with a local database dump
+        /* Part 2: Normalization of mutation mentions to dbSNP
+          This part communicates with a local database dump
          */
         final Properties property = new Properties();
-        property.loadFromXML(new FileInputStream(new File("myProperty.xml"))); //Load property file
+        property.loadFromXML(Files.newInputStream(new File("myProperty.xml").toPath())); //Load property file
         final DatabaseConnection dbConnection = new DatabaseConnection(property);
 
         //Connect with local derby database and initialize prepared statements
@@ -255,10 +255,10 @@ public class SETH {
         UniprotFeature.init(dbConnection, property.getProperty("database.uniprot"));
         Gene.init(dbConnection, property.getProperty("database.geneTable"), property.getProperty("gene2Pubmed"));
 
-        /**
-         * For mutation normalization, SETH requires target gene(s) to normalize the mutation
-         * For simpler use, SETH ships with a set of precomputed NER results from GNAT and gene2Pubmed
-         * but in practise an arbitrary gene name recognition tool can be used. As long it normalizes to Entrez-Gene IDs
+        /*
+          For mutation normalization, SETH requires target gene(s) to normalize the mutation
+          For simpler use, SETH ships with a set of precomputed NER results from GNAT and gene2Pubmed
+          but in practise an arbitrary gene name recognition tool can be used. As long as it normalizes to Entrez-Gene IDs
          */
         //Set<Gene> recognizedGenes = Gene.queryGenesForArticle(1572656); //Retrieve all genes recognized by GNAT and gene2pubmed
         Set<Integer> genes = new HashSet<Integer>(Collections.singletonList(1312));  //Manually define a list of Entrez Gene IDs, against which we want to compare; Alternatively you can include a custom gene-NER here

--- a/src/main/scala/seth/nen/Uniprot2Tab.scala
+++ b/src/main/scala/seth/nen/Uniprot2Tab.scala
@@ -61,7 +61,7 @@ object Uniprot2Tab extends App {
   val idReader = Source fromInputStream(new GZIPInputStream(new FileInputStream(args(1)))) bufferedReader()
   var line = idReader readLine()
   while (line != null) {
-    counter ++;
+    counter ++ ()
     val splits = line split("\t")
     if (splits(1) == "GeneID") mapping += splits(0) -> splits(2)
     line = idReader readLine()
@@ -93,7 +93,7 @@ object Uniprot2Tab extends App {
   var pos = ""
   var lastFeature: Feature = Feature("") //Avoid Nullpointer exception
   while (line != null) {
-    counter ++;
+    counter ++ ()
     line = line.trim
     if (line.startsWith("<accession>")) ids = line.substring(11, line.length-12) :: ids
     else if (line.startsWith("<feature") && line.contains("type=")) {

--- a/src/main/scala/seth/ner/SETHNER.scala
+++ b/src/main/scala/seth/ner/SETHNER.scala
@@ -16,7 +16,6 @@ import annotation.tailrec
  * Scala app for command line use of SETH
  */
 object SETHNERApp extends App {
-  //val SETH = new SETHNER
   val SETH = new SETHNER()
   if (args.size > 0) {
     for (sentence <- args(0).split("\n")) {

--- a/src/test/java/de/hu/berlin/wbi/HGNCTest.java
+++ b/src/test/java/de/hu/berlin/wbi/HGNCTest.java
@@ -2,7 +2,6 @@ package de.hu.berlin.wbi;
 
 import de.hu.berlin.wbi.objects.MutationMention;
 import junit.framework.TestCase;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import seth.SETH;
@@ -17,7 +16,7 @@ import java.util.List;
  *
  * Tests if a recognized mutation is correctly normalized to mutation nomenclature
  */
-public class HGNCTest {
+public class HGNCTest extends TestCase {
 
     private SETH seth;
 
@@ -29,8 +28,8 @@ public class HGNCTest {
     private void assertSingleMutation(String text, String hgnc){
         List<MutationMention> mutationMentions = seth.findMutations(text);
 
-        Assert.assertEquals(1, mutationMentions.size()); //We support only texts with one mutation
-        Assert.assertTrue(hgnc.equals(mutationMentions.get(0).toHGVS())); //Is the string contained in the provided text?
+        assertEquals(1, mutationMentions.size()); //We support only texts with one mutation
+        assertTrue(hgnc.equals(mutationMentions.get(0).toHGVS())); //Is the string contained in the provided text?
 
     }
 

--- a/src/test/java/de/hu/berlin/wbi/ImproveNER.java
+++ b/src/test/java/de/hu/berlin/wbi/ImproveNER.java
@@ -2,7 +2,6 @@ package de.hu.berlin.wbi;
 
 import de.hu.berlin.wbi.objects.MutationMention;
 import junit.framework.TestCase;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -15,7 +14,7 @@ import java.util.List;
  * A set of tests to improve some SETH false negatives
  */
 @Ignore("Test is ignored due to missing implementation!")
-public class ImproveNER {
+public class ImproveNER extends TestCase {
 
     private SETH seth;
 
@@ -29,11 +28,11 @@ public class ImproveNER {
      * @param text
      */
     private void assertSingleMutation(String text) {
-
+        System.out.println(text);
         List<MutationMention> mutationMentions = seth.findMutations(text);
-
-        Assert.assertEquals(1, mutationMentions.size());
-        Assert.assertEquals(text, mutationMentions.get(0).getText());
+        System.out.println(mutationMentions);
+        assertEquals(1, mutationMentions.size());
+        assertEquals(text, mutationMentions.get(0).getText());
     }
 
     @Test

--- a/src/test/java/de/hu/berlin/wbi/OldNomenclatureTest.java
+++ b/src/test/java/de/hu/berlin/wbi/OldNomenclatureTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import java.util.List;
 import seth.SETH;
 
-import static junit.framework.Assert.assertEquals;
 
 /**
  * Created with IntelliJ IDEA.
@@ -20,7 +19,7 @@ import static junit.framework.Assert.assertEquals;
  * JUnit tests derived from publications describing the current state of mutation nomenclature
  *
  */
-public class OldNomenclatureTest {
+public class OldNomenclatureTest extends TestCase {
 
     private SETH seth;
 
@@ -39,9 +38,9 @@ public class OldNomenclatureTest {
     private void assertSingleMutation(String text, String mutation){
         List<MutationMention> mutationMentions = seth.findMutations(text);
 
-        Assert.assertTrue(text.contains(mutation)); //Is the string contained in the provided text?
-        Assert.assertEquals(1, mutationMentions.size()); //We support only texts with one mutation
-        Assert.assertEquals(mutation, mutationMentions.get(0).getText()); //Is the substring identified?
+        assertTrue(text.contains(mutation)); //Is the string contained in the provided text?
+        assertEquals(1, mutationMentions.size()); //We support only texts with one mutation
+        assertEquals(mutation, mutationMentions.get(0).getText()); //Is the substring identified?
     }
 
     /**

--- a/src/test/java/seth/ITSETHNormalization.java
+++ b/src/test/java/seth/ITSETHNormalization.java
@@ -5,7 +5,6 @@ import de.hu.berlin.wbi.objects.MutationMention;
 import de.hu.berlin.wbi.objects.UniprotFeature;
 import de.hu.berlin.wbi.objects.dbSNP;
 import de.hu.berlin.wbi.objects.dbSNPNormalized;
-import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.junit.Ignore;
 
@@ -55,7 +54,7 @@ public class ITSETHNormalization extends TestCase {
         String sentence = "Causative GJB2 mutations were identified in 31 (15.2%) patients, and two common mutations, c.35delG and L90P (c.269T>C), accounted for 72.1% and 9.8% of GJB2 disease alleles.";
         List<MutationMention> mentions = seth.findMutations(sentence);
 
-        Assert.assertEquals(mentions.size(), 3);
+        assertEquals(mentions.size(), 3);
 
         // c.35delG and L90P (c.269T>C)
         Collections.sort(mentions, new Comparator<MutationMention>() {
@@ -73,20 +72,20 @@ public class ITSETHNormalization extends TestCase {
             m.normalizeSNP(potentialSNPs, features, true);
 
         // c.35delG
-        Assert.assertTrue(mentions.get(0).getNormalized().size() >= 1);
+        assertTrue(mentions.get(0).getNormalized().size() >= 1);
         dbSNPNormalized n1 = mentions.get(0).getNormalized().get(0);
         // We do this here because for dbsnp138+, rsid 1801002 no longer contains
         // this deletion.
-        Assert.assertTrue(n1.getRsID() == 80338939 || n1.getRsID() == 1801002);
+        assertTrue(n1.getRsID() == 80338939 || n1.getRsID() == 1801002);
 
         // L90P
-        Assert.assertEquals(mentions.get(1).getNormalized().size(), 1);
+        assertEquals(mentions.get(1).getNormalized().size(), 1);
         dbSNPNormalized n2 = mentions.get(1).getNormalized().get(0);
-        Assert.assertEquals(n2.getRsID(), 80338945);
+        assertEquals(n2.getRsID(), 80338945);
 
         // c.269T>C
-        Assert.assertEquals(mentions.get(2).getNormalized().size(), 1);
+        assertEquals(mentions.get(2).getNormalized().size(), 1);
         dbSNPNormalized n3 = mentions.get(2).getNormalized().get(0);
-        Assert.assertEquals(n3.getRsID(), 80338945);
+        assertEquals(n3.getRsID(), 80338945);
     }
 }

--- a/src/test/java/seth/SETHTest.java
+++ b/src/test/java/seth/SETHTest.java
@@ -10,6 +10,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
 public class SETHTest {
 
     @Test
@@ -18,7 +21,7 @@ public class SETHTest {
         String sentence = "Causative GJB2 mutations were identified in 31 (15.2%) patients, and two common mutations, c.35delG and L90P (c.269T>C), accounted for 72.1% and 9.8% of GJB2 disease alleles.";
         List<MutationMention> mentions = seth.findMutations(sentence);
 
-        Assert.assertEquals(mentions.size(), 3);
+        assertEquals(mentions.size(), 3);
 
         // c.35delG and L90P (c.269T>C)
         Collections.sort(mentions, new Comparator<MutationMention>() {
@@ -28,24 +31,24 @@ public class SETHTest {
             }
         });
 
-        Assert.assertEquals(mentions.get(0).getText(), "c.35delG");
-        Assert.assertEquals(mentions.get(1).getText(), "L90P");
-        Assert.assertEquals(mentions.get(2).getText(), "c.269T>C");
+        assertEquals(mentions.get(0).getText(), "c.35delG");
+        assertEquals(mentions.get(1).getText(), "L90P");
+        assertEquals(mentions.get(2).getText(), "c.269T>C");
 
-        Assert.assertEquals(mentions.get(0).getType(), Type.DELETION);
-        Assert.assertEquals(mentions.get(1).getType(), Type.SUBSTITUTION);
-        Assert.assertEquals(mentions.get(2).getType(), Type.SUBSTITUTION);
+        assertEquals(mentions.get(0).getType(), Type.DELETION);
+        assertEquals(mentions.get(1).getType(), Type.SUBSTITUTION);
+        assertEquals(mentions.get(2).getType(), Type.SUBSTITUTION);
 
-        Assert.assertEquals(mentions.get(0).getWtResidue(), "G");
-        Assert.assertEquals(mentions.get(1).getWtResidue(), "L");
-        Assert.assertEquals(mentions.get(2).getWtResidue(), "T");
+        assertEquals(mentions.get(0).getWtResidue(), "G");
+        assertEquals(mentions.get(1).getWtResidue(), "L");
+        assertEquals(mentions.get(2).getWtResidue(), "T");
 
-        Assert.assertEquals(mentions.get(0).getMutResidue(), null);
-        Assert.assertEquals(mentions.get(1).getMutResidue(), "P");
-        Assert.assertEquals(mentions.get(2).getMutResidue(), "C");
+        assertNull(mentions.get(0).getMutResidue());
+        assertEquals(mentions.get(1).getMutResidue(), "P");
+        assertEquals(mentions.get(2).getMutResidue(), "C");
 
-        Assert.assertEquals(mentions.get(0).getPosition(), "35");
-        Assert.assertEquals(mentions.get(1).getPosition(), "90");
-        Assert.assertEquals(mentions.get(2).getPosition(), "269");
+        assertEquals(mentions.get(0).getPosition(), "35");
+        assertEquals(mentions.get(1).getPosition(), "90");
+        assertEquals(mentions.get(2).getPosition(), "269");
     }
 }

--- a/src/test/scala/seth/ner/SETHSuite.scala
+++ b/src/test/scala/seth/ner/SETHSuite.scala
@@ -1,7 +1,12 @@
 package seth.ner
 
-import org.scalatest.{GivenWhenThen, FunSpec, FunSuite}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.GivenWhenThen
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+
+
 
 /**
  * User: rockt
@@ -9,8 +14,8 @@ import org.scalatest.matchers.ShouldMatchers
  * Time: 9:09 AM
  */
 
-class SETHSuite extends FunSpec with ShouldMatchers with GivenWhenThen{
-  val SETH = new SETHNER
+class SETHSuite extends AnyFunSpec with Matchers with GivenWhenThen{
+  val SETH = new SETHNER()
 
   def isValid(input: String, parser: SETH.Parser[Any]) = SETH.isValid(input, parser)
   def accept(input: String)(implicit parser: SETH.Parser[Any]) =
@@ -647,7 +652,7 @@ class SETHSuite extends FunSpec with ShouldMatchers with GivenWhenThen{
   }
 }
 
-class SingleTest extends FunSuite {
+class SingleTest extends AnyFunSuite {
   val SETH = new SETHNER(false)
   //val SETH = new SETHNER(true)
   test("Mutation object creation") {


### PR DESCRIPTION
This changes will allow to use Scala 2.12

### Changes to be able to compile with Scala 2.12
- _org.scala-lang >> scala-library_ **2.11.12 => 2.12.15**
- _org.scala-lang.modules >> scala-parser-combinators_2.11_ => _scala-parser-combinators_2.12_,  **1.0.3** => **2.1.1**
- org.scalatest: scalatest_2.11 **2.2.6 => 3.2.12**

Due to changes in **scalatest** some tests imports needed to be change too.

### Changes for vulnerable dependencies:
org.slf4j >> slf4j-log4j12 => slf4j-reload4j, **1.7.22 => 2.0.6**
log4j >> log4j **1.2.17** -> org.apache.logging.log4j >> log4j-core **2.20.0**
com.sun.jersey >> jersey-json **1.19** => org.codehaus.jettison >> jettison **1.5.3**